### PR TITLE
Make docker importable from top level

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -14,3 +14,4 @@ The main submodules are:
     modules/lyr
     modules/rad
     modules/settings
+    modules/docker

--- a/docs/source/modules/docker.rst
+++ b/docs/source/modules/docker.rst
@@ -1,0 +1,2 @@
+.. automodapi:: pypsg.docker
+    :no-main-docstr:

--- a/pypsg/__init__.py
+++ b/pypsg/__init__.py
@@ -10,3 +10,4 @@ from pypsg.rad import PyRad
 from pypsg.lyr import PyLyr
 from pypsg import settings
 from pypsg import units
+from . import docker


### PR DESCRIPTION
- add `from . import docker` to `__init__.py`
- add docker to docs